### PR TITLE
Cent OS/RedHat support, install unzip, use GitHub HTTPS download, fix version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-rclone_version: "1.32"
+rclone_version: "1.33"
 gather_facts: no

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,7 +12,10 @@ galaxy_info:
   - name: Debian
     versions:
     - jessie
+  - name: Ubuntu
+    versions:
+    - xenial
+  - name: CentOS 
   categories:
   - networking
   - system
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,7 @@
 - name: install rclone - copy binary
   copy:
     src: "{{ rclone_setup_tmp_dir}}/rclone-v{{ rclone_version }}-linux-amd64/rclone"
-    dest: "/usr/bin/rclone"
+    dest: "/usr/sbin/rclone"
     mode: 0755
     owner: root
     group: root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,7 +36,7 @@
     remote_src: true
   become: yes
 
-- name: Debian/Ubuntu install rclone - make dir for local manpages
+- name: Debian install rclone - make dir for local manpages
   file:
     path: /usr/local/share/man/man1
     state: directory

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,16 @@
   set_fact:
     rclone_setup_tmp_dir: "/tmp/rclone_setup"
 
+- name: Debian/Ubuntu  install unzip if needed
+  apt: name=unzip state=present
+  become: yes
+  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'    
+
+- name: Cent OS/RedHat install unzip if needed
+  yum: name=unzip state=present
+  become: yes
+  when: ansible_distribution == 'CentOS' or ansible_distribution == 'RedHat'
+
 - name: install rclone - make temp dir
   file:
     path: "{{ rclone_setup_tmp_dir}}"
@@ -11,7 +21,7 @@
 
 - name: install rclone - unzip package
   unarchive:
-    src: http://downloads.rclone.org/rclone-current-linux-amd64.zip
+    src: https://github.com/ncw/rclone/releases/download/v{{ rclone_version }}/rclone-v{{ rclone_version }}-linux-amd64.zip
     dest: "{{ rclone_setup_tmp_dir}}"
     copy: no
   become: yes
@@ -19,20 +29,31 @@
 - name: install rclone - copy binary
   copy:
     src: "{{ rclone_setup_tmp_dir}}/rclone-v{{ rclone_version }}-linux-amd64/rclone"
-    dest: "/usr/sbin/rclone"
+    dest: "/usr/bin/rclone"
     mode: 0755
     owner: root
     group: root
     remote_src: true
   become: yes
 
-- name: install rclone - make dir for local manpages
+- name: Debian/Ubuntu install rclone - make dir for local manpages
   file:
     path: /usr/local/share/man/man1
     state: directory
     mode: 0775
     owner: root
     group: staff
+  when: ansible_distribution == 'Debian'  
+
+- name: Cent OS/RedHat/Ubutnu install rclone - make dir for local manpages
+  file:
+    path: /usr/local/share/man/man1
+    state: directory
+    mode: 0775
+    owner: root
+    group: root
+  become: yes  
+  when: ansible_distribution == 'CentOS' or ansible_distribution == 'RedHat' or ansible_distribution == 'Ubuntu'
 
 - name: install rclone - copy manpage
   copy:


### PR DESCRIPTION
- Added Cent OS/RedHat support
- Installs unzip if needed
- Use /usr/bin/rclon instead of /usr/sbin/rclone since it is in the default PATH in Ubuntu and Cent OS.
- Use GitHub downloads links for HTTPS support + the other link randomly timed out.
- Fixed outdated version