### PR TITLE
Don't try to install makewhatis on CentOS 6

### DIFF
--- a/vars/CentOS-6.yml
+++ b/vars/CentOS-6.yml
@@ -3,7 +3,6 @@
 PACKAGES:
   - unzip
   - man
-  - makewhatis
 
 MAN_PAGES:
   OWNER: root


### PR DESCRIPTION
This command is provided by the "man" package on CentOS 6 so the
install will fail since "makewhatis" isn't a package in the default repositories on this OS.

Here is what I'm seeing on a fresh CentOS 6 installation:

```
[root@centos6 ~]# which makewhatis
/usr/sbin/makewhatis
[root@centos6 ~]# yum whatprovides /usr/sbin/makewhatis
Loaded plugins: fastestmirror
Determining fastest mirrors
 * base: mirror.cogentco.com
 * extras: mirror.vcu.edu
 * updates: mirror.trouble-free.net
base                                                 | 3.7 kB     00:00     
base/primary_db                                      | 4.7 MB     00:00     
extras                                               | 3.4 kB     00:00     
extras/primary_db                                    |  29 kB     00:00     
updates                                              | 3.4 kB     00:00     
updates/primary_db                                   | 1.4 MB     00:00     
man-1.6f-39.el6.x86_64 : A set of documentation tools: man, apropos and
                       : whatis
Repo        : base
Matched from:
Filename    : /usr/sbin/makewhatis



man-1.6f-39.el6.x86_64 : A set of documentation tools: man, apropos and
                       : whatis
Repo        : installed
Matched from:
Other       : Provides-match: /usr/sbin/makewhatis
```