### PR TITLE
Rewrite download section to automatically get the latest version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ ansible role to install [rclone](https://github.com/ncw/rclone)
 
 Usage:
 
-1. clone this repo into your local roles-directory
-2. add role to the hosts you want rclone installed to:
-3. The variable `rclone_version` can be defined as a release on github or `beta`. 
+1. Clone this repo into your local roles-directory
+2. Add role to the hosts you want rclone installed to:
+3. The variable `rclone_version` can be defined as a release on github or `beta`. If undefined, the latest stable version is installed.
 
 ``` ---
 - hosts: rclone-hosts

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,13 +1,12 @@
 ---
-#rclone version can be defined as a release number or as beta
-rclone_version: "1.46"
 # rclone_arch can be defined as an architecture (e.g. arm, mips, 386) listed at https://github.com/ncw/rclone/releases
 rclone_arch: amd64
-gather_facts: no
 
 install_manpages: true
 
 # Defaults in case no variables for OS are chosen
+rclone_setup_tmp_dir: "/tmp/rclone_setup"
+
 PACKAGES:
   - unzip
 

--- a/tasks/beta.yml
+++ b/tasks/beta.yml
@@ -1,0 +1,17 @@
+---
+- block:
+    - name: Check latest beta rclone version number
+      uri:
+        url: https://beta.rclone.org/version.txt
+        return_content: yes
+      register:
+        rclone_latest_beta_version
+    - set_fact:
+        rclone_version: "{{ rclone_latest_beta_version.content | replace ('rclone v', '', 1) | trim }}"
+
+- name: Get rclone latest beta version
+  unarchive:
+    src: https://beta.rclone.org/rclone-beta-latest-linux-{{ rclone_arch }}.zip
+    dest: "{{ rclone_setup_tmp_dir }}"
+    remote_src: yes
+    creates: "{{ rclone_setup_tmp_dir }}/rclone-v{{ rclone_version }}-linux-{{ rclone_arch }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,17 +1,12 @@
 ---
-- debug: var=ansible_os_family
-- name: gather os specific variables
+- name: Gather OS specific variables
   include_vars: "{{ item }}"
   with_first_found:
-    - '{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml'
+    - '{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml'
     - '{{ ansible_distribution }}.yml'
     - '{{ ansible_os_family }}.yml'
   tags:
     - vars
-
-- name: rclone - define tmpdir
-  set_fact:
-    rclone_setup_tmp_dir: "/tmp/rclone_setup"
 
 - name: Install required packages
   package:
@@ -20,58 +15,31 @@
   become: yes
   with_items: '{{ PACKAGES }}'
 
-- name: install rclone - make temp dir
+- name: Create temporary working directory
   file:
-    path: "{{ rclone_setup_tmp_dir}}"
+    path: "{{ rclone_setup_tmp_dir }}"
     state: directory
     mode: 0775
 
-- name: install rclone - unzip package
-  unarchive:
-    src: https://github.com/ncw/rclone/releases/download/v{{ rclone_version }}/rclone-v{{ rclone_version }}-linux-{{ rclone_arch }}.zip
-    dest: "{{ rclone_setup_tmp_dir}}"
-    copy: no
-    creates: '/tmp/rclone_setup/rclone-v{{ rclone_version }}-linux-{{ rclone_arch }}'
-  when: rclone_version != 'beta'
-  become: yes
+- name: Do stable install
+  include_tasks: stable.yml
+  when: rclone_version is undefined or rclone_version != 'beta'
 
-- name: install rclone - download file containing current beta version number
-  get_url:
-    url: https://beta.rclone.org/version.txt
-    dest: '{{ rclone_setup_tmp_dir }}/version.txt'
-  when: rclone_version == "beta"
-
-- name: install rclone - read in beta version number from {{ rclone_setup_tmp_dir }}/version.txt
-  slurp:
-    src: '{{ rclone_setup_tmp_dir }}/version.txt'
-  register: rclone_version_beta
+- name: Do beta install
+  include_tasks: beta.yml
   when: rclone_version == 'beta'
 
-- name: install rclone - format rclone_beta_version variable and redefine as rclone_version
-  set_fact:
-    rclone_version: "{{ rclone_version_beta['content'] | b64decode | replace ('rclone v', '', 1) | trim }}"
-  when: rclone_version == 'beta'
-
-- name: install rclone - unzip package
-  unarchive:
-    src: https://beta.rclone.org/rclone-beta-latest-linux-{{ rclone_arch }}.zip
-    dest: "{{ rclone_setup_tmp_dir}}"
-    copy: no
-    creates: '/tmp/rclone_setup/rclone-v{{ rclone_version }}-linux-{{ rclone_arch }}'
-  when: rclone_version_beta
-  become: yes
-
-- name: install rclone - copy binary
+- name: Copy rclone binary
   copy:
     src: "{{ rclone_setup_tmp_dir}}/rclone-v{{ rclone_version }}-linux-{{ rclone_arch }}/rclone"
-    dest: "/usr/sbin/rclone"
+    dest: "/usr/bin/rclone"
     mode: 0755
     owner: root
     group: root
     remote_src: true
   become: yes
 
-- name: install rclone - make dir for local manpages
+- name: Make dir for local manpages
   file:
     path: '{{ MAN_PAGES.PATH }}'
     state: directory
@@ -81,7 +49,7 @@
   become: yes
   when: install_manpages
 
-- name: install rclone - copy manpage
+- name: Copy rclone manpage
   copy:
     src: "{{ rclone_setup_tmp_dir}}/rclone-v{{ rclone_version }}-linux-{{ rclone_arch }}/rclone.1"
     dest: "{{ MAN_PAGES.PATH }}/rclone.1"
@@ -92,7 +60,7 @@
   become: yes
   when: install_manpages
 
-- name: install rclone - install manpage
+- name: Update mandb
   shell: mandb
   become: yes
   changed_when: false

--- a/tasks/stable.yml
+++ b/tasks/stable.yml
@@ -1,0 +1,18 @@
+---
+- block:
+    - name: Check latest stable rclone version number
+      uri:
+        url: https://downloads.rclone.org/version.txt
+        return_content: yes
+      register:
+        rclone_latest_version
+    - set_fact:
+        rclone_version: "{{ rclone_latest_version.content | replace ('rclone v', '', 1) | trim }}"
+  when: rclone_version is undefined
+
+- name: Get rclone stable version {{ rclone_version }}
+  unarchive:
+    src: https://downloads.rclone.org/v{{ rclone_version }}/rclone-v{{ rclone_version }}-linux-{{ rclone_arch }}.zip
+    dest: "{{ rclone_setup_tmp_dir }}"
+    remote_src: yes
+    creates: "{{ rclone_setup_tmp_dir }}/rclone-v{{ rclone_version }}-linux-{{ rclone_arch }}"


### PR DESCRIPTION
I've re-written the download logic to automatically get the latest stable version. rclone_version is no longer set as a default, but if provided as a variable, can be set to a specific version number or "beta" to install the latest beta version.

This will save you having to manually update the repo every time a new version is released.