### PR TITLE
GPG verify stable rclone

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,6 +43,7 @@
     group: root
     remote_src: true
   become: true
+  when: not ansible_check_mode
 
 - name: Make dir for local manpages
   file:
@@ -63,7 +64,7 @@
     group: root
     remote_src: true
   become: true
-  when: install_manpages
+  when: install_manpages and not ansible_check_mode
 
 - name: Update mandb
   command: mandb

--- a/tasks/stable.yml
+++ b/tasks/stable.yml
@@ -26,17 +26,21 @@
 
 - name: Do we have the rclone GPG Key?
   shell: gpg --list-keys FBF737ECE9F8AB18604BD2AC93935E02FF3B54FA
+  args:
+    warn: no
+  failed_when: gpg_key.rc not in [0,2]
   register: gpg_key
 
 - name: Get rclone GPG Key if we don't have it
   shell: gpg --recv-keys FBF737ECE9F8AB18604BD2AC93935E02FF3B54FA
-  when: gpg_key.rc != 0
+  when: gpg_key.rc is defined and gpg_key.rc != 0
 
 - name: Check that SHA256SUMS is signed by the GPG key and that the downloaded archive matches
   shell: sha256sum -c --ignore-missing <(gpg --verify --trust-model always --output=- SHA256SUMS)
   args:
     chdir: "{{ rclone_setup_tmp_dir }}"
     executable: /bin/bash
+  when: gpg_key.rc is defined
 
 - name: Extract rclone stable version {{ rclone_version }}
   unarchive:
@@ -44,4 +48,4 @@
     dest: "{{ rclone_setup_tmp_dir }}"
     remote_src: yes
     creates: "{{ rclone_setup_tmp_dir }}/rclone-v{{ rclone_version }}-linux-{{ rclone_arch }}"
-
+  when: not ansible_check_mode

--- a/tasks/stable.yml
+++ b/tasks/stable.yml
@@ -12,9 +12,36 @@
         rclone_version: "{{ rclone_latest_version.content | replace ('rclone v', '', 1) | trim }}"
   when: rclone_version is undefined
 
-- name: Get rclone stable version {{ rclone_version }}
-  unarchive:
-    src: https://downloads.rclone.org/v{{ rclone_version }}/rclone-v{{ rclone_version }}-linux-{{ rclone_arch }}.zip
+- name: Get rclone stable SHA256SUMS version {{ rclone_version }}
+  get_url:
+    url: https://downloads.rclone.org/v{{ rclone_version }}/SHA256SUMS
     dest: "{{ rclone_setup_tmp_dir }}"
-    remote_src: true
+    force: no
+
+- name: Get rclone stable archive version {{ rclone_version }}
+  get_url:
+    url: https://downloads.rclone.org/v{{ rclone_version }}/rclone-v{{ rclone_version }}-linux-{{ rclone_arch }}.zip
+    dest: "{{ rclone_setup_tmp_dir }}"
+    force: no
+
+- name: Do we have the rclone GPG Key?
+  shell: gpg --list-keys FBF737ECE9F8AB18604BD2AC93935E02FF3B54FA
+  register: gpg_key
+
+- name: Get rclone GPG Key if we don't have it
+  shell: gpg --recv-keys FBF737ECE9F8AB18604BD2AC93935E02FF3B54FA
+  when: gpg_key.rc != 0
+
+- name: Check that SHA256SUMS is signed by the GPG key and that the downloaded archive matches
+  shell: sha256sum -c --ignore-missing <(gpg --verify --trust-model always --output=- SHA256SUMS)
+  args:
+    chdir: "{{ rclone_setup_tmp_dir }}"
+    executable: /bin/bash
+
+- name: Extract rclone stable version {{ rclone_version }}
+  unarchive:
+    src: "{{ rclone_setup_tmp_dir }}/rclone-v{{ rclone_version }}-linux-{{ rclone_arch }}.zip"
+    dest: "{{ rclone_setup_tmp_dir }}"
+    remote_src: yes
     creates: "{{ rclone_setup_tmp_dir }}/rclone-v{{ rclone_version }}-linux-{{ rclone_arch }}"
+


### PR DESCRIPTION
This downloads the SHA256SUMS and the GPG key of the author (which I sure hope is right!) and verifies the download.  This is good for security, but also integrity of the download.  I only did this on the stable side of things, I'm not sure if the betas are similarly signed and verified.