### PR TITLE
Quote mode

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,7 @@ molecule:
   stage: test
   script:
     - docker -v
+    - docker run hello-world
     - python -V
     # - pip install ansible molecule docker
     - ansible --version

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,12 @@
 ---
+
 image: quay.io/ansible/molecule
+
 stages:
   - test
+
+services:
+  - docker:dind
 
 variables:
   PIP_CACHE_DIR: "$CI_PROJECT_DIR/.pip"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,27 @@
+---
+image: quay.io/ansible/molecule
+stages:
+  - test
+
+variables:
+  PIP_CACHE_DIR: "$CI_PROJECT_DIR/.pip"
+
+cache:
+  paths:
+    - .pip/
+    - virtenv/
+
+# before_script:
+# - pip install virtualenv
+# - virtualenv virtenv
+# - source virtenv/bin/activate
+
+molecule:
+  stage: test
+  script:
+    - docker -v
+    - python -V
+    # - pip install ansible molecule docker
+    - ansible --version
+    - molecule --version
+    - molecule test

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,7 +24,7 @@
   file:
     path: "{{ rclone_setup_tmp_dir }}"
     state: directory
-    mode: 0775
+    mode: '0775'
 
 - name: Do stable install
   include_tasks: stable.yml
@@ -38,7 +38,7 @@
   copy:
     src: "{{ rclone_setup_tmp_dir }}/rclone-v{{ rclone_version }}-linux-{{ rclone_arch }}/rclone"
     dest: "/usr/bin/rclone"
-    mode: 0755
+    mode: '0755'
     owner: root
     group: root
     remote_src: true
@@ -48,7 +48,7 @@
   file:
     path: '{{ MAN_PAGES.PATH }}'
     state: directory
-    mode: 0775
+    mode: '0775'
     owner: '{{ MAN_PAGES.OWNER }}'
     group: '{{ MAN_PAGES.GROUP }}'
   become: true
@@ -58,7 +58,7 @@
   copy:
     src: "{{ rclone_setup_tmp_dir }}/rclone-v{{ rclone_version }}-linux-{{ rclone_arch }}/rclone.1"
     dest: "{{ MAN_PAGES.PATH }}/rclone.1"
-    mode: 0644
+    mode: '0644'
     owner: root
     group: root
     remote_src: true


### PR DESCRIPTION
Noticed strange permissions after using the ansible copy module lately and found this in the docs:

```
You must either add a leading zero so that Ansible's YAML parser knows it is an octal number (like 0644 or 01777) or quote it (like '644' or '1777') so Ansible receives a string and can do its own conversion from string into number.
```
Same for the file-module, so I quoted these values now.