### PR TITLE
remove support for Ubuntu 14.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ env:
     - MOLECULE_DISTRO: fedora27
     - MOLECULE_DISTRO: ubuntu1804
     - MOLECULE_DISTRO: ubuntu1604
-    - MOLECULE_DISTRO: ubuntu1404
     - MOLECULE_DISTRO: debian10
     - MOLECULE_DISTRO: debian9
     - MOLECULE_DISTRO: debian8

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -24,7 +24,6 @@ galaxy_info:
       versions:
         - bionic
         - xenial
-        - trusty
   galaxy_tags:
     - networking
     - system

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -73,14 +73,6 @@ platforms:
     privileged: true
     pre_build_image: true
 
-  - name: ubuntu1404
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu1404}-ansible:latest"
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: false
-    pre_build_image: true
-
   - name: ubuntu1604
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu1604}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}


### PR DESCRIPTION
Removed tests and meta-info for Ubuntu Linux 14.04, as it started breaking tests (seems that the repos went away etc). I assume that not too many people use that anymore anyway.
