### PR TITLE
Adds vars for XBian

### DIFF
--- a/vars/XBian.yml
+++ b/vars/XBian.yml
@@ -1,0 +1,10 @@
+---
+
+PACKAGES:
+  - unzip
+  - man-db
+
+MAN_PAGES:
+  OWNER: root
+  GROUP: root
+  PATH: '/usr/share/man/man1'


### PR DESCRIPTION
I just copied the Debian.yml to XBian.yml to make this work on an XBian installation.

XBian is a debian/raspbian based distribution for XBMC and it reports itself as this:
PRETTY_NAME="XBian 1.0 (knockout)"
NAME=XBian
VERSION_ID=1.0
VERSION="1.0 (knockout)"
ID=raspbian
ID_LIKE=debian
ANSI_COLOR="1;31"
HOME_URL="http://www.xbian.org/"
SUPPORT_URL="http://forum.xbian.org/"
BUG_REPORT_URL="https://github.com/xbianonpi/xbian/issues"