### PR TITLE
add pre_task to wait for systemd initialization: DNF failed in Fedora…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
 
 script:
   # Run tests.
-  - molecule test -s travis
+  - molecule test
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,13 @@ env:
     - ROLE_NAME: ansible-rclone
   matrix:
     - MOLECULE_DISTRO: centos7
-    - MOLECULE_DISTRO: fedora32
-    - MOLECULE_DISTRO: fedora31
-    - MOLECULE_DISTRO: fedora30
-    - MOLECULE_DISTRO: fedora29
-    - MOLECULE_DISTRO: fedora27
-    - MOLECULE_DISTRO: ubuntu1804
-    - MOLECULE_DISTRO: ubuntu1604
+    - MOLECULE_DISTRO: centos8
     - MOLECULE_DISTRO: debian10
     - MOLECULE_DISTRO: debian9
-    - MOLECULE_DISTRO: debian8
+    - MOLECULE_DISTRO: fedora31
+    - MOLECULE_DISTRO: fedora30
+    - MOLECULE_DISTRO: ubuntu1804
+    - MOLECULE_DISTRO: ubuntu1604
 
 install:
   # Install test dependencies.

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - MOLECULE_DISTRO: debian9
     - MOLECULE_DISTRO: fedora31
     - MOLECULE_DISTRO: fedora30
+    - MOLECULE_DISTRO: ubuntu2004
     - MOLECULE_DISTRO: ubuntu1804
     - MOLECULE_DISTRO: ubuntu1604
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -23,6 +23,7 @@ galaxy_info:
         - 30
     - name: Ubuntu
       versions:
+        - focal
         - bionic
         - xenial
   galaxy_tags:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,14 +13,11 @@ galaxy_info:
       versions:
         - buster
         - stretch
-        - jessie
     - name: Fedora
       versions:
         - 32
         - 31
         - 30
-        - 29
-        - 27
     - name: Ubuntu
       versions:
         - bionic

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,13 +9,16 @@ galaxy_info:
   license: 'GNU General Public License v3'
   min_ansible_version: '2.0'
   platforms:
+    - name: EL
+      versions:
+        - 6
+        - 7
     - name: Debian
       versions:
         - buster
         - stretch
     - name: Fedora
       versions:
-        - 32
         - 31
         - 30
     - name: Ubuntu

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -7,7 +7,7 @@
     - name: Update apt cache.
       apt: update_cache=true cache_valid_time=600
       when: ansible_os_family == 'Debian'
-    - name: Wait for systemd to complete initialization.
+    - name: Wait for systemd to complete initialization.     # noqa 303
       command: systemctl is-system-running
       register: systemctl_status
       until: >

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -7,14 +7,14 @@
     - name: Update apt cache.
       apt: update_cache=true cache_valid_time=600
       when: ansible_os_family == 'Debian'
-    - name: Wait for systemd to complete initialization.          # noqa 303
+    - name: Wait for systemd to complete initialization.
       command: systemctl is-system-running
       register: systemctl_status
-      until: "'running' in systemctl_status.stdout"
+      until: >
+        'running' in systemctl_status.stdout or
+        'degraded' in systemctl_status.stdout
       retries: 30
       delay: 5
-      # first line made Debian VMs fail, so I decided to filter for Fedora distribution
-      # when: ansible_service_mgr == 'systemd'
       when: ansible_distribution == 'Fedora'
       changed_when: false
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,8 +1,12 @@
 ---
 - name: Converge
   hosts: all
+  become: true
+
   pre_tasks:
-    # https://www.jeffgeerling.com/blog/2020/resolving-fedora-dnf-error-no-such-file-or-directory-varlibdnfrpmdblockpid
+    - name: Update apt cache.
+      apt: update_cache=true cache_valid_time=600
+      when: ansible_os_family == 'Debian'
     - name: Wait for systemd to complete initialization.          # noqa 303
       command: systemctl is-system-running
       register: systemctl_status

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,94 +8,13 @@ lint: |
   yamllint .
   ansible-lint
 platforms:
-  - name: centos7
+  - name: instance
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: false
     pre_build_image: true
-
-  - name: debian8
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian8}-ansible:latest"
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: false
-    pre_build_image: true
-
-  - name: debian9
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian9}-ansible:latest"
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: false
-    pre_build_image: true
-
-  - name: debian10
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian10}-ansible:latest"
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: false
-    pre_build_image: true
-
-  - name: fedora27
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-fedora27}-ansible:latest"
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: false
-    pre_build_image: true
-
-  - name: fedora29
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-fedora29}-ansible:latest"
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: false
-    pre_build_image: true
-
-  - name: fedora30
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-fedora30}-ansible:latest"
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    pre_build_image: true
-
-  - name: fedora31
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-fedora31}-ansible:latest"
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    pre_build_image: true
-
-  - name: fedora32
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-fedora32}-ansible:latest"
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    pre_build_image: true
-
-  - name: ubuntu1604
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu1604}-ansible:latest"
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: false
-    pre_build_image: true
-
-  - name: ubuntu1804
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu1804}-ansible:latest"
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: false
-    pre_build_image: true
-
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,9 +6,8 @@ driver:
 lint: |
   set -e
   yamllint .
-  ansible-lint ./molecule/playbook.yml
+  ansible-lint
 platforms:
-
   - name: centos7
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
@@ -100,25 +99,6 @@ platforms:
 provisioner:
   name: ansible
   playbooks:
-    converge: ../playbook.yml
+    converge: ${MOLECULE_PLAYBOOK:-converge.yml}
   lint:
     name: ansible-lint
-scenario:
-  name: default
-  test_sequence:
-    - lint
-    - destroy
-    # - dependency
-    - syntax
-    - create
-    # - prepare
-    - converge
-    - idempotence
-    # - side_effect
-    - verify
-    - destroy
-verifier:
-  name: testinfra
-  directory: ../tests/
-  lint:
-    name: flake8

--- a/molecule/playbook.yml
+++ b/molecule/playbook.yml
@@ -3,14 +3,14 @@
   hosts: all
   pre_tasks:
     # https://www.jeffgeerling.com/blog/2020/resolving-fedora-dnf-error-no-such-file-or-directory-varlibdnfrpmdblockpid
-    - name: Wait for systemd to complete initialization. # noqa 303
+    - name: Wait for systemd to complete initialization.          # noqa 303
       command: systemctl is-system-running
       register: systemctl_status
       until: "'running' in systemctl_status.stdout"
       retries: 30
       delay: 5
-      ## first line made Debian VMs fail, so I decided to filter for Fedora distribution
-      #when: ansible_service_mgr == 'systemd'
+      # first line made Debian VMs fail, so I decided to filter for Fedora distribution
+      # when: ansible_service_mgr == 'systemd'
       when: ansible_distribution == 'Fedora'
       changed_when: false
 

--- a/molecule/playbook.yml
+++ b/molecule/playbook.yml
@@ -1,5 +1,18 @@
 ---
 - name: Converge
   hosts: all
+  pre_tasks:
+    # https://www.jeffgeerling.com/blog/2020/resolving-fedora-dnf-error-no-such-file-or-directory-varlibdnfrpmdblockpid
+    - name: Wait for systemd to complete initialization. # noqa 303
+      command: systemctl is-system-running
+      register: systemctl_status
+      until: "'running' in systemctl_status.stdout"
+      retries: 30
+      delay: 5
+      ## first line made Debian VMs fail, so I decided to filter for Fedora distribution
+      #when: ansible_service_mgr == 'systemd'
+      when: ansible_distribution == 'Fedora'
+      changed_when: false
+
   roles:
     - role: ansible-rclone


### PR DESCRIPTION
The Fedora VMs failed at `molecule converge` 

```
The error was: FileNotFoundError: [Errno 2] No such file or directory: '/var/cache/dnf/metadata_lock.pid'
```

Found something similar at:

https://www.jeffgeerling.com/blog/2020/resolving-fedora-dnf-error-no-such-file-or-directory-varlibdnfrpmdblockpid

and

https://github.com/geerlingguy/ansible-role-composer/issues/54

I modified the `pre_task` to only execute in Fedora VMs. Debian and Ubuntu failed for me with the original line.
