### PR TITLE
Fix molecule tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
 
 install:
   # Install test dependencies.
-  - pip install molecule==3.0.5 docker yamllint ansible-lint
+  - pip install molecule==3.0.6 docker==4.2.2 yamllint ansible-lint
 
 script:
   - molecule --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
 
 install:
   # Install test dependencies.
-  - pip install molecule docker yamllint ansible-lint
+  - pip install molecule==3.0.5 docker yamllint ansible-lint
 
 script:
   - molecule --version


### PR DESCRIPTION
molecule tests broke, because `docker-py` recently calls docker API 1.39 and Travis seems to only support 1.38.

Very likely something like this:

https://github.com/docker/docker-py/issues/2639

Switching back to `pip3 install docker==4.2.2` fixes my molecule runs in Travis.