### PR TITLE
Add logic for release

### DIFF
--- a/.github/workflows/molecule_test.yml
+++ b/.github/workflows/molecule_test.yml
@@ -35,6 +35,7 @@ jobs:
         versions:
           - stable
           - beta
+          - 1.50.2
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/molecule_test.yml
+++ b/.github/workflows/molecule_test.yml
@@ -32,10 +32,11 @@ jobs:
           - ubuntu1604
           - ubuntu1804
           - ubuntu2004
-        versions:
+        releases:
           - stable
           - beta
-          - 1.50.2
+        versions:
+          - "1.53.3"
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -45,6 +46,7 @@ jobs:
         uses: robertdebock/molecule-action@2.6.3
         env:
           MOLECULE_DISTRO: "${{ matrix.distros }}"
+          TEST_RELEASE: "${{ matrix.releases }}"
           TEST_VERSION: "${{ matrix.versions }}"
         with:
           options: parallel

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,11 @@
 # rclone_arch can be defined as an architecture (e.g. arm, mips, 386) listed at https://github.com/ncw/rclone/releases
 rclone_arch: amd64
 
+# release of rclone to use. 'default' or 'beta' are accepted
+rclone_release: stable
+rclone_version: ''
+
+
 install_manpages: true
 
 # Defaults in case no variables for OS are chosen

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -22,7 +22,8 @@ provisioner:
   inventory:
     host_vars:
       instance:
-        rclone_version: ${TEST_VERSION:-stable}
+        rclone_release: ${TEST_RELEASE:-stable}
+        rclone_version: ${TEST_VERSION:-''}
   lint:
     name: ansible-lint
 scenario:

--- a/tasks/beta.yml
+++ b/tasks/beta.yml
@@ -9,11 +9,15 @@
     - name: Set variable for beta version
       set_fact:
         rclone_version: "{{ rclone_latest_beta_version.content | replace ('rclone v', '', 1) | trim }}"
+        beta_version_url: https://beta.rclone.org/rclone-beta-latest-linux-{{ rclone_arch }}.zip
+  when:
+    - rclone_version | length == 0
 
-- name: Get rclone latest beta version
+- name: Get rclone beta version
   unarchive:
-    src: https://beta.rclone.org/rclone-beta-latest-linux-{{ rclone_arch }}.zip
+    src: "{{ beta_version_url | default('https://beta.rclone.org/v' + rclone_version + '/rclone-v' + rclone_version + '-linux-' + rclone_arch + '.zip') }}"
     dest: "{{ rclone_setup_tmp_dir }}"
     remote_src: true
     mode: 0644
     creates: "{{ rclone_setup_tmp_dir }}/rclone-v{{ rclone_version }}-linux-{{ rclone_arch }}"
+    list_files: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,17 +27,21 @@
     state: directory
     mode: '0775'
 
-- name: Do stable install
-  include_tasks: stable.yml
-  when:
-    - rclone_version is undefined or
-      rclone_version == 'stable' or
-      rclone_version != 'beta'
+- name: debug rclone_version
+  debug:
+    var: rclone_version
 
 - name: Do beta install
   include_tasks: beta.yml
   when: rclone_version == 'beta'
 
+- name: Do stable install
+  include_tasks: stable.yml
+  when:
+    - rclone_version is undefined or
+      rclone_version == 'stable' or
+      rclone_version != 'beta' or
+      rclone_version
 - name: Copy rclone binary
   copy:
     src: "{{ rclone_setup_tmp_dir }}/rclone-v{{ rclone_version }}-linux-{{ rclone_arch }}/rclone"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,15 +33,26 @@
 
 - name: Do beta install
   include_tasks: beta.yml
-  when: rclone_version == 'beta'
+  when: rclone_release == 'beta'
 
 - name: Do stable install
   include_tasks: stable.yml
-  when:
-    - rclone_version is undefined or
-      rclone_version == 'stable' or
-      rclone_version != 'beta' or
-      rclone_version
+  when: rclone_release == 'stable'
+
+- name: Get list of files extracted from the rclone archive
+  find:
+    path: "{{ rclone_setup_tmp_dir }}"
+    depth: 2
+    file_type: directory
+  register: rclone_archive
+
+- name: Validate the version in the archive matches the expected version ({{ rclone_version }})
+  fail:
+    msg: >
+      "The version of rclone ({{ rclone_archive.files[0].path | basename }}) in
+      the archive does not match the expected version ({{ rclone_version }})"
+  when: rclone_version not in rclone_archive.files[0].path
+
 - name: Copy rclone binary
   copy:
     src: "{{ rclone_setup_tmp_dir }}/rclone-v{{ rclone_version }}-linux-{{ rclone_arch }}/rclone"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,10 +27,6 @@
     state: directory
     mode: '0775'
 
-- name: debug rclone_version
-  debug:
-    var: rclone_version
-
 - name: Do beta install
   include_tasks: beta.yml
   when: rclone_release == 'beta'

--- a/tasks/stable.yml
+++ b/tasks/stable.yml
@@ -11,8 +11,7 @@
       set_fact:
         rclone_version: "{{ rclone_latest_version.content | replace ('rclone v', '', 1) | trim }}"
   when:
-    - rclone_version is undefined or
-      rclone_version == 'stable'
+    - rclone_version | length == 0
 
 - name: Get rclone stable version {{ rclone_version }}
   unarchive:


### PR DESCRIPTION
- Adds ability to specify version when using beta release
- Adds logic to fail when the version in the rclone archive doesn't match what is expected

Fixes stefangweichinger/ansible-rclone#66
Fixes stefangweichinger/ansible-rclone#68