### PR TITLE
only release code from master branch

### DIFF
--- a/.github/workflows/molecule_test.yml
+++ b/.github/workflows/molecule_test.yml
@@ -62,3 +62,4 @@ jobs:
         uses: robertdebock/galaxy-action@1.1.0
         with:
           galaxy_api_key: ${{ secrets.galaxy_api_key }}
+        if: ${{ github.ref == 'refs/heads/master' }}


### PR DESCRIPTION
Edit action workflow: only run the release step when the branch is master