### PR TITLE
run config file install as root

### DIFF
--- a/tasks/install-config.yml
+++ b/tasks/install-config.yml
@@ -5,6 +5,7 @@
     path: '{{ rclone_config_location | dirname }}'
     state: directory
     mode: '0700'
+  become: true
   when: rclone_configs is defined
 
 - name: Set up rclone config
@@ -12,4 +13,5 @@
     src: rclone.conf.j2
     dest: '{{ rclone_config_location }}'
     mode: 0600
+  become: true
   when: rclone_configs is defined


### PR DESCRIPTION
This is a follow-up of PR #85 : the config file installation must be run as root