### PR TITLE
reduce test matrix: drop centos7, ubuntu 16.x, fedora < 32

### DIFF
--- a/.github/workflows/molecule_test.yml
+++ b/.github/workflows/molecule_test.yml
@@ -24,13 +24,11 @@ jobs:
         scenario:
           - default
         distros:
-          - centos7
           - centos8
           - debian10
           - debian9
           - fedora32
           - fedora33
-          - ubuntu1604
           - ubuntu1804
           - ubuntu2004
         releases:

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Please note that this role installs rclone from the upstream repository and not 
 
 The build tests run on a selected set of distros, currently I decided to use the last two releases of each CentOS, Debian, Fedora, Ubuntu.
 
-* CentOS 7,8
-* Debian 8,9,10
-* Fedora 30,31,32,33
-* Ubuntu 1604,1804,2004
+* CentOS 8
+* Debian 9,10
+* Fedora 32,33
+* Ubuntu 1804,2004
 * Ubuntu derivated distros: Linux Mint, Pop!\_OS
 
 Some older releases also work with this role, but I decided to remove some of them from `galaxy_info`.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Please note that this role installs rclone from the upstream repository and not 
 
 ## Supported Platforms
 
-The build tests run on a selected set of distros, currently I decided to use the last two releases of each CentOS, Debian, Fedora, Ubuntu.
+The build tests run on a selected set of distros:
 
 * CentOS 8
 * Debian 9,10

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,7 +12,6 @@ galaxy_info:
   platforms:
     - name: EL
       versions:
-        - 7
         - 8
     - name: Debian
       versions:
@@ -22,13 +21,10 @@ galaxy_info:
       versions:
         - 33
         - 32
-        - 31
-        - 30
     - name: Ubuntu
       versions:
         - focal
         - bionic
-        - xenial
   galaxy_tags:
     - networking
     - system


### PR DESCRIPTION
To reduce the number of test runs I remove older distros from the matrix of tested and supported operating systems /releases.

This doesn't mean that the role doesn't work there anymore!
