### PR TITLE
add branch to release action

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -74,4 +74,5 @@ jobs:
         uses: robertdebock/galaxy-action@1.1.1
         with:
           galaxy_api_key: ${{ secrets.galaxy_api_key }}
+          git_branch: main
         if: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
The action uses "master" as default branch, that one doesn't exist here.
So I have to set that to "main" instead.