### PR TITLE
Add Ubuntu 22 to supported platforms

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -44,6 +44,7 @@ jobs:
           - fedora36
           - ubuntu1804
           - ubuntu2004
+          - ubuntu2204
         releases:
           - stable
           - beta

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The build tests run on a selected set of distros:
 
 * Debian 9,10,11
 * Fedora 34,35,36
-* Ubuntu 1804,2004
+* Ubuntu 1804,2004,2204
 * Ubuntu-derived distros: Linux Mint, Pop!\_OS
 
 Some older releases also work with this role, but I decided to remove some of them from `galaxy_info`.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The build tests run on a selected set of distros:
 * Debian 9,10,11
 * Fedora 34,35,36
 * Ubuntu 1804,2004
-* Ubuntu derivated distros: Linux Mint, Pop!\_OS
+* Ubuntu-derived distros: Linux Mint, Pop!\_OS
 
 Some older releases also work with this role, but I decided to remove some of them from `galaxy_info`.
 PRs welcome, but we can't test on every platform.


### PR DESCRIPTION
Added Ubuntu 22 to Molecule and README (also a slight grammar fix inside the latter)