### PR TITLE
correct-permissions-of-config-directory

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -75,7 +75,7 @@
         state: directory
         owner: '{{ rclone_config_owner.OWNER }}'
         group: '{{ rclone_config_owner.GROUP }}'
-        mode: '0700'
+        mode: '0755'
 
     - name: Set up rclone config
       ansible.builtin.template:


### PR DESCRIPTION
fixes #131 

If `rclone_config_location` is set to something common like `/etc` by the user, the former `mode: 0600` would have broken permissions for other software. This patch fixes this bug.
