### PR TITLE
Fix molecule tests

### DIFF
--- a/.github/workflows/galaxy.yml
+++ b/.github/workflows/galaxy.yml
@@ -1,0 +1,18 @@
+---
+#
+# Ansible managed
+#
+
+name: Release to Ansible Galaxy
+
+on:
+  release:
+    types: [created, edited, published, released]
+jobs:
+  release:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: galaxy
+        uses: robertdebock/galaxy-action@1.2.1
+        with:
+          galaxy_api_key: ${{ secrets.galaxy_api_key }}

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -45,6 +45,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: "${{ github.repository }}"
+      - name: Workaround Git Security Warning
+        run: |
+          # Workaround a bug in github actions:
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: molecule
         uses: robertdebock/molecule-action@4.0.7
         env:

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -57,7 +57,7 @@ jobs:
           # Workaround a bug in github actions:
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: molecule
-        uses: robertdebock/molecule-action@5.0.3
+        uses: robertdebock/molecule-action@4.0.9
         env:
           MOLECULE_DISTRO: "${{ matrix.distros }}"
           TEST_RELEASE: "${{ matrix.releases }}"

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -50,22 +50,10 @@ jobs:
           # Workaround a bug in github actions:
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: molecule
-        uses: robertdebock/molecule-action@4.0.7
+        uses: robertdebock/molecule-action@4.0.9
         env:
           MOLECULE_DISTRO: "${{ matrix.distros }}"
           TEST_RELEASE: "${{ matrix.releases }}"
           TEST_VERSION: "${{ matrix.versions }}"
         with:
           scenario: ${{ matrix.scenario }}
-
-  release:
-    needs:
-      - test
-    runs-on: ubuntu-20.04
-    steps:
-      - name: galaxy
-        uses: robertdebock/galaxy-action@1.2.1
-        with:
-          galaxy_api_key: ${{ secrets.galaxy_api_key }}
-          git_branch: main
-        if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -35,15 +35,8 @@ jobs:
           - debian10
           - debian11
           - debian12
-          - fedora34
-          - fedora35
-          - fedora36
-          - ubuntu1804
-          - ubuntu2004
-          - ubuntu2204
         releases:
           - stable
-          - beta
         versions:
           - "1.60.0"
           - ""

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -20,12 +20,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
-        with:
-          path: "${{ github.repository }}"
-      - name: molecule
-        uses: robertdebock/molecule-action@4.0.9
-        with:
-          command: lint
+      - name: ansible-lint
+        uses: ansible-community/ansible-lint-action@main
   test:
     needs:
       - lint

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           path: "${{ github.repository }}"
       - name: molecule
-        uses: robertdebock/molecule-action@4.0.9
+        uses: robertdebock/molecule-action@4.0.7
         env:
           MOLECULE_DISTRO: "${{ matrix.distros }}"
           TEST_RELEASE: "${{ matrix.releases }}"

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -56,7 +56,6 @@ jobs:
           TEST_RELEASE: "${{ matrix.releases }}"
           TEST_VERSION: "${{ matrix.versions }}"
         with:
-          options: parallel
           scenario: ${{ matrix.scenario }}
 
   release:

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -35,8 +35,15 @@ jobs:
           - debian10
           - debian11
           - debian12
+          - fedora34
+          - fedora35
+          - fedora36
+          - ubuntu1804
+          - ubuntu2004
+          - ubuntu2204
         releases:
           - stable
+          - beta
         versions:
           - "1.60.0"
           - ""

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -57,7 +57,7 @@ jobs:
           # Workaround a bug in github actions:
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: molecule
-        uses: robertdebock/molecule-action@4.0.9
+        uses: robertdebock/molecule-action@5.0.3
         env:
           MOLECULE_DISTRO: "${{ matrix.distros }}"
           TEST_RELEASE: "${{ matrix.releases }}"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,16 +15,13 @@ galaxy_info:
         - '8'
     - name: Debian
       versions:
-        - buster
-        - stretch
-        - bullseye
+        - all
     - name: Fedora
       versions:
         - all
     - name: Ubuntu
       versions:
-        - focal
-        - bionic
+        - all        
   galaxy_tags:
     - networking
     - system

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -21,7 +21,7 @@ galaxy_info:
         - all
     - name: Ubuntu
       versions:
-        - all        
+        - all
   galaxy_tags:
     - networking
     - system

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -24,18 +24,3 @@ provisioner:
       instance:
         rclone_release: ${TEST_RELEASE:-stable}
         rclone_version: ${TEST_VERSION:-''}
-  lint:
-    name: ansible-lint
-scenario:
-  test_sequence:
-    - lint
-    - destroy
-    # - dependency
-    - syntax
-    - create
-    # - prepare
-    - converge
-    - idempotence
-    # - side_effect
-    - verify
-    - destroy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+# Pinning ansible-compat version due to [bug](https://github.com/ansible-community/molecule/issues/3903)
+ansible-compat == 3.0.2
+molecule == 5.*
+molecule-plugins[docker] == 23.*
+ansible-lint == 6.*
+paramiko == 3.*

--- a/tox.ini
+++ b/tox.ini
@@ -2,18 +2,17 @@
 # Ansible managed
 #
 [tox]
-minversion = 3.21.4
-envlist = py{310}-ansible-{4,5}
+minversion = 4.2.4
+envlist = py{310}-ansible{6,7,8}
 
 skipsdist = true
 
 [testenv]
 deps =
-    4: ansible == 4.*
-    5: ansible == 5.*
-    molecule[docker]
-    docker == 5.*
-    ansible-lint == 5.*
+    -rrequirements.txt
+    ansible6: ansible == 6.*
+    ansible7: ansible == 7.*
+    ansible8: ansible == 8.*
 commands = molecule test
 setenv =
     TOX_ENVNAME={envname}
@@ -21,4 +20,8 @@ setenv =
     ANSIBLE_FORCE_COLOR=1
     ANSIBLE_ROLES_PATH=../
 
-passenv = namespace image tag DOCKER_HOST
+passenv =
+    namespace
+    image
+    tag
+    DOCKER_HOST


### PR DESCRIPTION
The whole molecule-testing pipeline is more complex already than the actual ansible role ;-)

Tried to update and fix the testing, had to add and edit some things.

* the molecule-tests and releasing to galaxy are now in two separate workflows
* tox.ini and requirements.txt were updated
* linting is done using another gh-action now
* no more linting with molecule
* the molecule-test-scenario is set to default now
* for now I stay with `robertdebock/molecule-action@4.0.9` and merge to master: v5 needs more changes