### PR TITLE
Use original fact names instead of injected ones

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -9,7 +9,7 @@
       ansible.builtin.apt:
         update_cache: yes
         cache_valid_time: 600
-      when: ansible_os_family == 'Debian'
+      when: ansible_facts.os_family == 'Debian'
 
     - name: Wait for systemd to complete initialization.     # noqa command-instead-of-module
       ansible.builtin.command: systemctl is-system-running
@@ -19,7 +19,7 @@
         'degraded' in systemctl_status.stdout
       retries: 30
       delay: 5
-      when: ansible_distribution == 'Fedora'
+      when: ansible_facts.distribution == 'Fedora'
       changed_when: false
 
     - name: Show ansible version

--- a/tasks/install-bin.yml
+++ b/tasks/install-bin.yml
@@ -5,7 +5,7 @@
   ansible.builtin.apt:
     update_cache: true
   become: true
-  when: ansible_distribution == 'Ubuntu'
+  when: ansible_facts.distribution == 'Ubuntu'
 
 - name: Install required packages
   ansible.builtin.package:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,9 +3,9 @@
 - name: Gather OS specific variables
   ansible.builtin.include_vars: "{{ item }}"
   with_first_found:
-    - '{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml'
-    - '{{ ansible_distribution }}.yml'
-    - '{{ ansible_os_family }}.yml'
+    - '{{ ansible_facts.distribution }}-{{ ansible_facts.distribution_major_version }}.yml'
+    - '{{ ansible_facts.distribution }}.yml'
+    - '{{ ansible_facts.os_family }}.yml'
   tags:
     - vars
 

--- a/templates/etc/ansible/facts.d/rclone.fact.j2
+++ b/templates/etc/ansible/facts.d/rclone.fact.j2
@@ -1,4 +1,4 @@
-#!{{ ansible_python['executable'] }}
+#!{{ ansible_facts.python['executable'] }}
 # -*- coding: utf-8 -*-
 
 # Copyright (C) 2018 Maciej Delmanowski <drybjed@gmail.com>


### PR DESCRIPTION
Thank you very much for this very useful role. In my setup I have to set `INJECT_FACTS_AS_VARS=false` in `ansible.cfg` which means that facts of the `ansible_facts` variable are not injected into the top level `vars` variable. To use this role I had to redefine the missing variables like this:

```
ansible_distribution: "{{ ansible_facts.distribution }}"
ansible_python: "{{ ansible_facts.python }}"
```

To avoid this kind of issues it would be better if this project uses the original variables names (e.g. `ansible_facts.distribution` instead of `ansible_distribution`). This PR tries to accomplish that.