### PR TITLE
Add default include_vars to avoid not found error

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,7 @@
     - '{{ ansible_facts.distribution }}-{{ ansible_facts.distribution_major_version }}.yml'
     - '{{ ansible_facts.distribution }}.yml'
     - '{{ ansible_facts.os_family }}.yml'
+    - 'default.yml'
   tags:
     - vars
 

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,0 +1,8 @@
+---
+
+rclone_packages: []  # noqa var-naming
+
+rclone_man_pages:  # noqa var-naming
+  OWNER: root
+  GROUP: root
+  PATH: '/usr/local/share/man/man1'


### PR DESCRIPTION
On some machines, include_vars fails because the distribution and OS family information is not public. (eg. shared rental server)
Add a default include file to execute subsequent tasks in such cases as well.