### PR TITLE
Add `force` parameter to `ansible.builtin.copy` for rclone upgrading

### DIFF
--- a/tasks/install-bin.yml
+++ b/tasks/install-bin.yml
@@ -49,6 +49,7 @@
     mode: '0755'
     owner: root
     group: root
+    force: true
     remote_src: true
   become: true
 
@@ -69,6 +70,7 @@
     mode: '0644'
     owner: root
     group: root
+    force: true
     remote_src: true
   become: true
   when: install_manpages


### PR DESCRIPTION
`ansible.builtin.copy` does not copy files if it already exists by default.
So, even when you want to upgrade, the file will not be overwritten.