### PR TITLE
Support installation by non-root users

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -22,4 +22,4 @@ commitizen:
     - ''
   - - disabled
     - fg:#858585 italic
-  version: 0.1.3
+  version: 0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## Unreleased
+
+## 0.2.0 [2024-08-04]
+
+- installation for non-root users
+- improvements in the molecule setup: arch-linux as separate platform, everything in default scenario
+
+## 0.1.3 - 0.1.9 TODO
 
 ## 0.1.2 (2023-03-09)
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The location to install the `rclone` binary.
 
 These variables allow for setting the ownership of the `rclone` binary. They are mostly needed if configuring `rclone` to install for non-root user.
 
-    rclone_binary_location: "/home/rclone/.local/bin/rclone/rclone"
+    rclone_binary_location: "/home/rclone/.local/bin/"
     rclone_binary_owner:
        OWNER: rclone
        GROUP: rclone

--- a/README.md
+++ b/README.md
@@ -57,6 +57,37 @@ Available variables are listed below, along with default values (see `defaults/m
 
 This can be used to toggle the installation of manpages.
 
+### `rclone_manpages_location: "{{ default_rclone_manpages_location }}"`
+
+The location to install `rclone` manpages. The default is an OS specific location, but you can override it anywhere.
+
+### `rclone_manpages_owner:`
+
+These variables allow for setting the ownership of manpages for `rclone`. They are mostly needed if configuring `rclone` to run as an other user than root (maybe a specific backup user or so).
+
+    rclone_manpages_owner:
+       OWNER: rclone
+       GROUP: rclone
+
+### `rclone_binary_location: "/usr/local/bin/"`
+
+The location to install the `rclone` binary.
+
+### `rclone_binary_owner:`
+
+These variables allow for setting the ownership of the `rclone` binary. They are mostly needed if configuring `rclone` to install for non-root user.
+
+    rclone_binary_location: "/home/rclone/.local/bin/rclone/rclone"
+    rclone_binary_owner:
+       OWNER: rclone
+       GROUP: rclone
+
+### rclone_fact_path: "/etc/ansible/facts.d/rclone.fact"
+
+The location to ansible local facts for `rclone`. They are mostly needed if you run this role by non-root user.
+
+    rclone_fact_path: "/home/rclone/.config/ansible/facts.d/rclone.fact"
+
 ### `rclone_arch: "amd64"`
 
 This variable chooses the target architecture (for example 'amd64').
@@ -176,6 +207,8 @@ Note: This example assumes you have created the `rclone.service` systemd unit yo
 ### `rclone_mounts: ""`
 
 This variable allows for the configuration of rclone mounts within your infrastructure. `rclone_mounts` should be a YAML list of objects, each including keys for `name`, `remote_name`, `remote_path`, `local_path`, `auto_mount`, and `extra_args`. This setup enables precise control over multiple mount points, their remote sources, and whether they should be automatically mounted.
+
+If you use this variable, you must run this role as root using `become: true`.
 
 #### Detailed example for `rclone_mounts`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,8 @@ rclone_release: stable
 
 rclone_version: '{{ ansible_local.rclone.version | d("0.0.0") }}'
 
+rclone_fact_path: "/etc/ansible/facts.d/rclone.fact"
+
 install_manpages: true
 
 # Defaults in case no variables for OS are chosen

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,12 +14,19 @@ install_manpages: true
 # Defaults in case no variables for OS are chosen
 rclone_setup_tmp_dir: "/tmp/rclone_setup"
 
+# The location to install the binary file
+rclone_binary_location: "/usr/local/bin/"
+
 # The location to install the config file if configured
 rclone_config_location: "/root/.config/rclone/rclone.conf"
 
 rclone_packages: "{{ default_rclone_packages }}"
 
 rclone_man_pages:
+  OWNER: root
+  GROUP: root
+
+rclone_binary_owner:
   OWNER: root
   GROUP: root
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,9 @@ install_manpages: true
 # Defaults in case no variables for OS are chosen
 rclone_setup_tmp_dir: "/tmp/rclone_setup"
 
+# The location to install manpages
+rclone_manpages_location: "{{ default_rclone_manpages_location }}"
+
 # The location to install the binary file
 rclone_binary_location: "/usr/local/bin/"
 
@@ -22,7 +25,7 @@ rclone_config_location: "/root/.config/rclone/rclone.conf"
 
 rclone_packages: "{{ default_rclone_packages }}"
 
-rclone_man_pages:
+rclone_manpages_owner:
   OWNER: root
   GROUP: root
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,8 +17,7 @@ rclone_setup_tmp_dir: "/tmp/rclone_setup"
 # The location to install the config file if configured
 rclone_config_location: "/root/.config/rclone/rclone.conf"
 
-rclone_packages:
-  - unzip
+rclone_packages: "{{ default_rclone_packages }}"
 
 rclone_man_pages:
   OWNER: root

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 name: ansible_rclone
 namespace: stefangweichinger
-version: 0.1.7
+version: 0.2.0
 authors:
   - stefangweichinger
 readme: ./README.md

--- a/tasks/beta.yml
+++ b/tasks/beta.yml
@@ -7,3 +7,4 @@
     mode: 0744
     list_files: true
     creates: "{{ rclone_setup_tmp_dir }}/rclone-v{{ rclone_version }}-linux-{{ rclone_arch }}"
+  changed_when: False

--- a/tasks/install-bin.yml
+++ b/tasks/install-bin.yml
@@ -55,25 +55,27 @@
 
 - name: Make dir for local manpages
   ansible.builtin.file:
-    path: '{{ rclone_man_pages.PATH }}'
+    path: '{{ rclone_manpages_location }}'
     state: directory
     mode: '0775'
-    owner: '{{ rclone_man_pages.OWNER }}'
-    group: '{{ rclone_man_pages.GROUP }}'
+    owner: '{{ rclone_manpages_owner.OWNER }}'
+    group: '{{ rclone_manpages_owner.GROUP }}'
   when: install_manpages
 
 - name: Copy rclone manpage
   ansible.builtin.copy:
     src: "{{ rclone_setup_tmp_dir }}/rclone-v{{ rclone_version }}-linux-{{ rclone_arch }}/rclone.1"
-    dest: "{{ rclone_man_pages.PATH }}/rclone.1"
+    dest: "{{ rclone_manpages_location }}/rclone.1"
     mode: '0644'
-    owner: root
-    group: root
+    owner: '{{ rclone_manpages_owner.OWNER }}'
+    group: '{{ rclone_manpages_owner.GROUP }}'
     force: true
     remote_src: true
   when: install_manpages
 
 - name: Update mandb
   ansible.builtin.command: mandb
+  environment:
+    MANPATH: "{{ rclone_manpages_location | dirname }}"
   changed_when: false
   when: install_manpages

--- a/tasks/install-bin.yml
+++ b/tasks/install-bin.yml
@@ -46,10 +46,10 @@
 - name: Copy rclone binary
   ansible.builtin.copy:
     src: "{{ rclone_setup_tmp_dir }}/rclone-v{{ rclone_version }}-linux-{{ rclone_arch }}/rclone"
-    dest: "/usr/local/bin/rclone"
+    dest: '{{ rclone_binary_location }}'
     mode: '0755'
-    owner: root
-    group: root
+    owner: '{{ rclone_binary_owner.OWNER }}'
+    group: '{{ rclone_binary_owner.GROUP }}'
     force: true
     remote_src: true
 

--- a/tasks/install-bin.yml
+++ b/tasks/install-bin.yml
@@ -27,6 +27,7 @@
     path: "{{ rclone_setup_tmp_dir }}"
     state: directory
     mode: '0775'
+  changed_when: False
 
 - name: Do beta install
   ansible.builtin.include_tasks: beta.yml

--- a/tasks/install-bin.yml
+++ b/tasks/install-bin.yml
@@ -5,7 +5,9 @@
   ansible.builtin.apt:
     update_cache: true
   become: true
-  when: ansible_facts.distribution == 'Ubuntu'
+  when: >-
+    rclone_packages | length > 0
+    and ansible_facts.distribution == 'Ubuntu'
 
 - name: Install required packages
   ansible.builtin.package:
@@ -13,6 +15,7 @@
     state: present
   become: true
   with_items: '{{ rclone_packages }}'
+  when: rclone_packages | length > 0
 
 - name: Remove temporary working directory
   ansible.builtin.file:

--- a/tasks/install-bin.yml
+++ b/tasks/install-bin.yml
@@ -4,7 +4,6 @@
 - name: Update repositories cache on Ubuntu
   ansible.builtin.apt:
     update_cache: true
-  become: true
   when: >-
     rclone_packages | length > 0
     and ansible_facts.distribution == 'Ubuntu'
@@ -13,7 +12,6 @@
   ansible.builtin.package:
     name: '{{ item }}'
     state: present
-  become: true
   with_items: '{{ rclone_packages }}'
   when: rclone_packages | length > 0
 
@@ -54,7 +52,6 @@
     group: root
     force: true
     remote_src: true
-  become: true
 
 - name: Make dir for local manpages
   ansible.builtin.file:
@@ -63,7 +60,6 @@
     mode: '0775'
     owner: '{{ rclone_man_pages.OWNER }}'
     group: '{{ rclone_man_pages.GROUP }}'
-  become: true
   when: install_manpages
 
 - name: Copy rclone manpage
@@ -75,11 +71,9 @@
     group: root
     force: true
     remote_src: true
-  become: true
   when: install_manpages
 
 - name: Update mandb
   ansible.builtin.command: mandb
-  become: true
   changed_when: false
   when: install_manpages

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,23 +11,21 @@
     - vars
 
 - name: Create directory for ansible custom facts
-  become: true
   ansible.builtin.file:
     state: directory
     recurse: true
-    path: /etc/ansible/facts.d
+    path: "{{ rclone_fact_path | dirname }}"
 
 - name: Create facts file from template
-  become: true
   ansible.builtin.template:
     src: 'etc/ansible/facts.d/rclone.fact.j2'
-    dest: /etc/ansible/facts.d/rclone.fact
+    dest: '{{ rclone_fact_path }}'
     mode: '0755'
   notify: Update facts
 
 - name: Re-read facts after adding custom fact
-  become: true
   ansible.builtin.setup:
+    fact_path: "{{ rclone_fact_path }}"
     filter: ansible_local
 
 - name: Handle stable version number

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -66,7 +66,6 @@
 
 - name: Install configs
   when: rclone_configs is defined
-  become: true
   block:
     - name: Create config directory
       ansible.builtin.file:

--- a/tasks/stable.yml
+++ b/tasks/stable.yml
@@ -6,3 +6,4 @@
     remote_src: true
     mode: 0744
     creates: "{{ rclone_setup_tmp_dir }}/rclone-v{{ rclone_version }}-linux-{{ rclone_arch }}"
+  changed_when: False

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -5,7 +5,4 @@ default_rclone_packages:
   - man
   - file
 
-rclone_man_pages:
-  OWNER: root
-  GROUP: root
-  PATH: '/usr/local/share/man/man1'
+default_rclone_manpages_location: '/usr/local/share/man/man1'

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -1,6 +1,6 @@
 ---
 
-rclone_packages:
+default_rclone_packages:
   - unzip
   - man
   - file

--- a/vars/CentOS-6.yml
+++ b/vars/CentOS-6.yml
@@ -1,6 +1,6 @@
 ---
 
-rclone_packages:
+default_rclone_packages:
   - unzip
   - man
 

--- a/vars/CentOS-6.yml
+++ b/vars/CentOS-6.yml
@@ -4,7 +4,4 @@ default_rclone_packages:
   - unzip
   - man
 
-rclone_man_pages:
-  OWNER: root
-  GROUP: root
-  PATH: '/usr/local/share/man/man1'
+default_rclone_manpages_location: '/usr/local/share/man/man1'

--- a/vars/CentOS-7.yml
+++ b/vars/CentOS-7.yml
@@ -1,6 +1,6 @@
 ---
 
-rclone_packages:
+default_rclone_packages:
   - unzip
   - man-db
 

--- a/vars/CentOS-7.yml
+++ b/vars/CentOS-7.yml
@@ -4,7 +4,4 @@ default_rclone_packages:
   - unzip
   - man-db
 
-rclone_man_pages:
-  OWNER: root
-  GROUP: root
-  PATH: '/usr/local/share/man/man1'
+default_rclone_manpages_location: '/usr/local/share/man/man1'

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,6 +1,6 @@
 ---
 
-rclone_packages:
+default_rclone_packages:
   - unzip
   - man-db
 

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -4,7 +4,4 @@ default_rclone_packages:
   - unzip
   - man-db
 
-rclone_man_pages:
-  OWNER: root
-  GROUP: root
-  PATH: '/usr/share/man/man1'
+default_rclone_manpages_location: '/usr/share/man/man1'

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -5,7 +5,4 @@ default_rclone_packages:
   - man
   - file
 
-rclone_man_pages:
-  OWNER: root
-  GROUP: root
-  PATH: '/usr/local/share/man/man1'
+default_rclone_manpages_location: '/usr/local/share/man/man1'

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -1,6 +1,6 @@
 ---
 
-rclone_packages:
+default_rclone_packages:
   - unzip
   - man
   - file

--- a/vars/Linuxmint.yml
+++ b/vars/Linuxmint.yml
@@ -1,6 +1,6 @@
 ---
 
-rclone_packages:
+default_rclone_packages:
   - unzip
   - man-db
 

--- a/vars/Linuxmint.yml
+++ b/vars/Linuxmint.yml
@@ -4,7 +4,4 @@ default_rclone_packages:
   - unzip
   - man-db
 
-rclone_man_pages:
-  OWNER: root
-  GROUP: root
-  PATH: '/usr/local/share/man/man1'
+default_rclone_manpages_location: '/usr/local/share/man/man1'

--- a/vars/Pop!_OS.yml
+++ b/vars/Pop!_OS.yml
@@ -1,6 +1,6 @@
 ---
 
-rclone_packages:
+default_rclone_packages:
   - unzip
   - man-db
 

--- a/vars/Pop!_OS.yml
+++ b/vars/Pop!_OS.yml
@@ -4,7 +4,4 @@ default_rclone_packages:
   - unzip
   - man-db
 
-rclone_man_pages:
-  OWNER: root
-  GROUP: root
-  PATH: '/usr/local/share/man/man1'
+default_rclone_manpages_location: '/usr/local/share/man/man1'

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -5,7 +5,4 @@ default_rclone_packages:
   - man
   - file
 
-rclone_man_pages:
-  OWNER: root
-  GROUP: root
-  PATH: '/usr/local/share/man/man1'
+default_rclone_manpages_location: '/usr/local/share/man/man1'

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,6 +1,6 @@
 ---
 
-rclone_packages:
+default_rclone_packages:
   - unzip
   - man
   - file

--- a/vars/SLES.yml
+++ b/vars/SLES.yml
@@ -4,7 +4,4 @@ default_rclone_packages:
   - unzip
   - man-pages
 
-rclone_man_pages:  # noqa var-naming
-  OWNER: root
-  GROUP: root
-  PATH: '/usr/local/share/man/man1'
+default_rclone_manpages_location: '/usr/local/share/man/man1'

--- a/vars/SLES.yml
+++ b/vars/SLES.yml
@@ -1,6 +1,6 @@
 ---
 
-rclone_packages:   # noqa var-naming
+default_rclone_packages:
   - unzip
   - man-pages
 

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -4,7 +4,4 @@ default_rclone_packages:
   - unzip
   - man-db
 
-rclone_man_pages:  # noqa var-naming
-  OWNER: root
-  GROUP: root
-  PATH: '/usr/local/share/man/man1'
+default_rclone_manpages_location: '/usr/local/share/man/man1'

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,6 +1,6 @@
 ---
 
-rclone_packages:   # noqa var-naming
+default_rclone_packages:
   - unzip
   - man-db
 

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -2,7 +2,4 @@
 
 default_rclone_packages: []
 
-rclone_man_pages:  # noqa var-naming
-  OWNER: root
-  GROUP: root
-  PATH: '/usr/local/share/man/man1'
+default_rclone_manpages_location: '/usr/local/share/man/man1'

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,6 +1,6 @@
 ---
 
-rclone_packages: []  # noqa var-naming
+default_rclone_packages: []
 
 rclone_man_pages:  # noqa var-naming
   OWNER: root

--- a/vars/openSUSE Leap.yml
+++ b/vars/openSUSE Leap.yml
@@ -4,7 +4,4 @@ default_rclone_packages:
   - unzip
   - man-pages
 
-rclone_man_pages:  # noqa var-naming
-  OWNER: root
-  GROUP: root
-  PATH: '/usr/local/share/man/man1'
+default_rclone_manpages_location: '/usr/local/share/man/man1'

--- a/vars/openSUSE Leap.yml
+++ b/vars/openSUSE Leap.yml
@@ -1,6 +1,6 @@
 ---
 
-rclone_packages:   # noqa var-naming
+default_rclone_packages:
   - unzip
   - man-pages
 


### PR DESCRIPTION
Closes #153

- Added support for running without `become: true` except for `rclone_mounts
- Added support for changing the location of manpages
- Added support for changing the location of binary
- Added support for avoiding installation of dependent packages (to avoid apt execution errors by non-root users)