### PR TITLE
Fix check mode

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -53,6 +53,15 @@ jobs:
         run: |
           # Workaround a bug in github actions:
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: molecule check
+        uses: robertdebock/molecule-action@6.0.1
+        env:
+          MOLECULE_DISTRO: "${{ matrix.distros }}"
+          TEST_RELEASE: "${{ matrix.releases }}"
+          TEST_VERSION: "${{ matrix.versions }}"
+        with:
+          scenario: ${{ matrix.scenario }}
+          command: check
       - name: molecule
         uses: robertdebock/molecule-action@6.0.1
         env:
@@ -85,6 +94,15 @@ jobs:
         run: |
           # Workaround a bug in github actions:
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: molecule check
+        uses: robertdebock/molecule-action@6.0.1
+        env:
+          MOLECULE_DISTRO: "${{ matrix.distros }}"
+          TEST_RELEASE: "${{ matrix.releases }}"
+          TEST_VERSION: "${{ matrix.versions }}"
+        with:
+          scenario: ${{ matrix.scenario }}
+          command: check
       - name: molecule
         uses: robertdebock/molecule-action@6.0.1
         env:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -29,6 +29,7 @@
       delay: 5
       when: ansible_facts.distribution == 'Fedora'
       changed_when: false
+      check_mode: false
 
     - name: Show ansible version
       ansible.builtin.debug:

--- a/tasks/beta.yml
+++ b/tasks/beta.yml
@@ -7,4 +7,5 @@
     mode: 0744
     list_files: true
     creates: "{{ rclone_setup_tmp_dir }}/rclone-v{{ rclone_version }}-linux-{{ rclone_arch }}"
-  changed_when: False
+  changed_when: false
+  check_mode: false

--- a/tasks/install-bin.yml
+++ b/tasks/install-bin.yml
@@ -27,7 +27,8 @@
     path: "{{ rclone_setup_tmp_dir }}"
     state: directory
     mode: '0775'
-  changed_when: False
+  changed_when: false
+  check_mode: false
 
 - name: Do beta install
   ansible.builtin.include_tasks: beta.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,7 @@
     state: directory
     recurse: true
     path: "{{ rclone_fact_path | dirname }}"
+  register: custom_facts_dir
 
 - name: Create facts file from template
   ansible.builtin.template:
@@ -22,6 +23,7 @@
     dest: '{{ rclone_fact_path }}'
     mode: '0755'
   notify: Update facts
+  when: custom_facts_dir.state is defined
 
 - name: Re-read facts after adding custom fact
   ansible.builtin.setup:

--- a/tasks/stable.yml
+++ b/tasks/stable.yml
@@ -6,4 +6,5 @@
     remote_src: true
     mode: 0744
     creates: "{{ rclone_setup_tmp_dir }}/rclone-v{{ rclone_version }}-linux-{{ rclone_arch }}"
-  changed_when: False
+  changed_when: false
+  check_mode: false


### PR DESCRIPTION
The role fails when Ansible is run in check mode because several directories do not exist.

>  msg: dest '/tmp/rclone_setup' must be an existing dir

I think its safe to create files under `/tmp` but the `rclone.fact` needs an exclusion.

